### PR TITLE
Add aliases to languages.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ rich = "*"
 prompt-toolkit = "*"
 requests = "*"
 pygments = "*"
+pyyaml = "~=5.1"
 
 [dev-packages]
 flake8 = "~=3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e65fe1159769a8ec8b870bd0eee2fc37906a32b8037579bf2356916eb7e9ca38"
+            "sha256": "f013052249059c73d6a8023fa5767f8f4d5d2912e8cab735a2a5c1a76deb143c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -56,19 +56,46 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:7e966747c18ececaec785699626b771c1ba8344c8d31759a1915d6b12fad6525",
-                "sha256:c96b30925025a7635471dc083ffb6af0cc67482a00611bd81aeaeeeb7e5a5e12"
+                "sha256:0fa02fa80363844a4ab4b8d6891f62dd0645ba672723130423ca4037b80c1974",
+                "sha256:62c811e46bd09130fb11ab759012a4ae385ce4fb2073442d1898867a824183bd"
             ],
             "index": "pypi",
-            "version": "==3.0.14"
+            "version": "==3.0.16"
         },
         "pygments": {
             "hashes": [
-                "sha256:bc9591213a8f0e0ca1a5e68a479b4887fdc3e75d0774e5c71c31920c427de435",
-                "sha256:df49d09b498e83c1a73128295860250b0b7edd4c723a32e9bc0d295c7c2ec337"
+                "sha256:37a13ba168a02ac54cc5891a42b1caec333e59b66addb7fa633ea8a6d73445c0",
+                "sha256:b21b072d0ccdf29297a82a2363359d99623597b8a265b8081760e4d0f7153c88"
             ],
             "index": "pypi",
-            "version": "==2.7.4"
+            "version": "==2.8.0"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"
+            ],
+            "index": "pypi",
+            "version": "==5.4.1"
         },
         "requests": {
             "hashes": [
@@ -80,11 +107,11 @@
         },
         "rich": {
             "hashes": [
-                "sha256:3070d53e3a93864de351c1091af1deb25f41e6051b33e485d4626b591c0cfdb3",
-                "sha256:e0f2db62a52536ee32f6f584a47536465872cae2b94887cf1f080fb9eaa13eb2"
+                "sha256:a8ee22199562278d2f78148cacb2f9460ccac362cd4a40f705505b41daae60e0",
+                "sha256:f8f08fdac6bd67dc2dd7fe976da702d748487aa9eb5d050c48b2321bc67ed659"
             ],
             "index": "pypi",
-            "version": "==9.10.0"
+            "version": "==9.11.0"
         },
         "typing-extensions": {
             "hashes": [
@@ -304,7 +331,7 @@
                 "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
                 "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "index": "pypi",
             "version": "==5.4.1"
         },
         "six": {

--- a/piston/commands/from_input.py
+++ b/piston/commands/from_input.py
@@ -1,10 +1,11 @@
+import itertools
 import json
 import random
 from typing import List, Tuple
 
 import requests
 from piston.colorschemes import scheme_dict, schemes
-from piston.utilities.compilers import languages_
+from piston.utilities.compilers import all_languages
 from piston.utilities.constants import init_lexers, lexers_dict, spinners
 from piston.utilities.utils import Utils
 from prompt_toolkit.lexers import PygmentsLexer
@@ -20,7 +21,7 @@ class FromInput:
 
     def __init__(self) -> None:
         init_lexers()
-        self.languages = languages_
+        self.languages = all_languages()
 
         self.console = Console()
         self.output_json = dict()
@@ -30,11 +31,15 @@ class FromInput:
     def get_lang(self) -> str:
         """Prompt the user for the programming language, close program if language not supported."""
         language = self.console.input("[green]Enter language:[/green] ").lower()
+        languages = itertools.chain.from_iterable(list(self.languages.values()))
 
-        if language not in self.languages:
+        if language not in languages:
             self.console.print("Language is not supported!", style="bold red")
             Utils.close()
-        return language
+
+        return [
+            lang for lang in self.languages.keys() if language in self.languages[lang]
+        ][0]
 
     def get_args(self) -> List[str]:
         """Prompt the user for the command line arguments."""

--- a/piston/commands/from_link.py
+++ b/piston/commands/from_link.py
@@ -1,3 +1,4 @@
+import itertools
 import json
 import random
 import urllib
@@ -6,7 +7,7 @@ from typing import List, Optional, Tuple, Union
 
 import requests
 from piston.colorschemes import schemes
-from piston.utilities.compilers import languages_
+from piston.utilities.compilers import all_languages
 from piston.utilities.constants import init_lexers, spinners
 from piston.utilities.utils import Utils
 from pygments.styles import get_all_styles
@@ -18,7 +19,7 @@ class FromLink:
 
     def __init__(self) -> None:
         init_lexers()
-        self.languages = languages_
+        self.languages = all_languages()
 
         self.console = Console()
         self.output_json = dict()
@@ -28,11 +29,15 @@ class FromLink:
     def get_lang(self) -> str:
         """Prompt the user for the programming language, close program if language not supported."""
         language = self.console.input("[green]Enter language:[/green] ").lower()
+        languages = itertools.chain.from_iterable(list(self.languages.values()))
 
-        if language not in self.languages:
+        if language not in languages:
             self.console.print("Language is not supported!", style="bold red")
             Utils.close()
-        return language
+
+        return [
+            lang for lang in self.languages.keys() if language in self.languages[lang]
+        ][0]
 
     def get_args(self) -> List[str]:
         """Prompt the user for the command line arguments."""

--- a/piston/commands/from_shell.py
+++ b/piston/commands/from_shell.py
@@ -1,3 +1,4 @@
+import itertools
 import json
 import random
 from dataclasses import dataclass
@@ -5,7 +6,7 @@ from typing import List
 
 import requests
 from piston.colorschemes import scheme_dict, schemes
-from piston.utilities.compilers import languages_
+from piston.utilities.compilers import all_languages
 from piston.utilities.constants import Shell, init_lexers, lexers_dict, spinners
 from piston.utilities.prompt_continuation import prompt_continuation
 from piston.utilities.utils import Utils
@@ -31,6 +32,7 @@ class FromShell:
 
     def __init__(self):
         init_lexers()
+        self.languages = all_languages()
 
         self.console = Console()
         self.themes = list(get_all_styles()) + schemes
@@ -60,11 +62,15 @@ class FromShell:
 
     def set_language(self, language: str) -> None:
         """Prompt the user for the programming language, close program if language not supported."""
-        if language not in languages_:
-            self.console.print("[bold red]Language is not supported![/bold red]")
+        languages = itertools.chain.from_iterable(list(self.languages.values()))
+
+        if language not in languages:
+            self.console.print("Language is not supported!", style="bold red")
             Utils.close()
 
-        self.language = language
+        self.language = [
+            lang for lang in self.languages.keys() if language in self.languages[lang]
+        ][0]
 
     def get_args(self) -> List[str]:
         """Prompt the user for the command line arguments."""

--- a/piston/utilities/compilers.py
+++ b/piston/utilities/compilers.py
@@ -1,37 +1,18 @@
-languages_ = [
-    "nasm",
-    "awk",
-    "bash",
-    "brainfuck",
-    "c",
-    "lisp",
-    "csharp",
-    "cpp",
-    "d",
-    "ruby",
-    "emacs",
-    "elixir",
-    "haskell",
-    "go",
-    "java",
-    "js",
-    "julia",
-    "kotlin",
-    "perl",
-    "php",
-    "python",
-    "python2",
-    "rust",
-    "swift",
-    "zig",
-    "paradox",
-    "nasm",
-    "crystal",
-    "dash",
-    "osabie",
-    "nim",
-    "deno",
-    "scala",
-    "typescript",
-    "lua",
-]
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+
+def load_languages() -> dict:
+    """Loads languages from the yml file containing the language and its aliases."""
+    with open(Path("piston/utilities/languages.yml"), "r") as stream:
+        languages = yaml.safe_load(stream)
+    return languages
+
+
+def all_languages() -> dict:
+    """Returns all the languages along with its alis in a nice dict lang: alias."""
+    languages = load_languages()
+    languages = {lang: aliases for d in languages for lang, aliases in d.items()}
+    return languages

--- a/piston/utilities/compilers.py
+++ b/piston/utilities/compilers.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Iterable
 
 import yaml
 

--- a/piston/utilities/constants.py
+++ b/piston/utilities/constants.py
@@ -1,7 +1,7 @@
 from pygments import lexers
 from pygments.styles import get_all_styles
 from piston.colorschemes import schemes
-from piston.utilities.compilers import languages_
+from piston.utilities.compilers import all_languages
 
 
 def init_lexers() -> None:
@@ -43,6 +43,7 @@ init_lexers()
 # https://github.com/pydanny/pygments-custom/blob/master/pygments/lexers/_mapping.py
 lexers_dict = {
     "nasm": lexers.asm.NasmLexer,
+    "nasm64": lexers.asm.NasmLexer,
     "awk": lexers.textedit.AwkLexer,
     "bash": lexers.shell.BashLexer,
     "brainfuck": lexers.esoteric.BrainfuckLexer,
@@ -62,7 +63,7 @@ lexers_dict = {
     "kotlin": lexers.jvm.KotlinLexer,
     "perl": lexers.perl.PerlLexer,
     "php": lexers.php.PhpLexer,
-    "python": lexers.python.Python3Lexer,
+    "python3": lexers.python.Python3Lexer,
     "python2": lexers.python.PythonLexer,
     "rust": lexers.rust.RustLexer,
     "swift": lexers.objective.SwiftLexer,
@@ -91,7 +92,8 @@ spinners = [
 themes = list(get_all_styles()) + schemes
 themes = [list(themes[style : style + 2]) for style in range(0, len(themes), 2)]
 
-languages_table = zip(iter(languages_), iter(languages_))
+languages = all_languages().keys()
+languages_table = zip(iter(languages), iter(languages))
 
 
 class Shell:

--- a/piston/utilities/constants.py
+++ b/piston/utilities/constants.py
@@ -36,6 +36,7 @@ def init_lexers() -> None:
     lexers.find_lexer_class_by_name("lua")
     lexers.find_lexer_class_by_name("crystal")
     lexers.find_lexer_class_by_name("text")
+    lexers.find_lexer_class_by_name("prolog")
 
 
 init_lexers()
@@ -77,6 +78,7 @@ lexers_dict = {
     "scala": lexers.jvm.ScalaLexer,
     "typescript": lexers.javascript.TypeScriptLexer,
     "lua": lexers.scripting.LuaLexer,
+    "prolog": lexers.prolog.LogtalkLexer,
 }
 
 spinners = [

--- a/piston/utilities/lang_extensions.py
+++ b/piston/utilities/lang_extensions.py
@@ -1,5 +1,5 @@
 lang_extensions = {
-    "py": "python",
+    "py": "python3",
     "cpp": "cpp",
     "c": "c",
     "js": "javascript",

--- a/piston/utilities/languages.yml
+++ b/piston/utilities/languages.yml
@@ -1,0 +1,118 @@
+---
+- nasm:
+  - asm
+  - nasm
+- nasm64:
+  - asm64
+  - nasm64
+- awk:
+  - awk
+- bash:
+  - bash
+  - sh
+- brainfuck:
+  - bf
+  - brainfuck
+- c:
+  - c
+- crystal:
+  - crystal
+  - cr
+- lisp:
+  - lisp
+  - commonlisp
+  - clisp
+  - cl
+- csharp:
+  - c#
+  - cs
+  - csharp
+- cpp:
+  - c++
+  - cpp
+  - cc
+  - cxx
+- d:
+  - dlang
+  - d
+- deno:
+  - deno
+  - denojs
+  - denots
+- dash:
+  - dash
+- ruby:
+  - duby
+  - rb
+  - ruby
+- emacs:
+  - el
+  - elisp
+  - emacs
+- elixir:
+  - elixir
+  - exs
+- haskell:
+  - haskell
+  - hs
+- go:
+  - go
+  - golang
+- java:
+  - java
+- nim:
+  - nim
+- js:
+  - javascript
+  - js
+  - node
+  - node.js
+- jelly:
+  - jelly
+- julia:
+  - jl
+  - julia
+- kotlin:
+  - kotlin
+  - kt
+- lua:
+  - lua
+- paradoc:
+  - paradoc
+- perl:
+  - perl
+  - pl
+- php:
+  - php
+  - php3
+  - php4
+  - php5
+- prolog:
+  - prolog
+  - plg
+- python3:
+  - py
+  - py3
+  - python
+  - python3
+- python2:
+  - python2
+  - py2
+- rust:
+  - rs
+  - rust
+- scala:
+  - scala
+  - sc
+- swift:
+  - swift
+- typescript:
+  - ts
+  - typescript
+- zig:
+  - zig
+- osabie:
+  - osabie
+  - 05AB1E
+  - osable
+  - usable


### PR DESCRIPTION
## Description
This pull request will add ` languages.yml` file, containing the languages and its aliases in the following way:
```yml
- language:
  - alias1
  - alias2
```
And also adds `prolog` language lexer, which was missing,

## Screenshots
<!-- Remove this section if the changes don't impact anything user-facing. -->
<!-- You can add images by just copy pasting them directly in the editor. -->

## Did you:
- [x] Join the [**Piston CLI Discord Community**](https://discord.gg/c7dZ4zdGQT)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?