### PR TITLE
Prevent keyboard interrupt errors

### DIFF
--- a/piston/commands/from_file.py
+++ b/piston/commands/from_file.py
@@ -1,5 +1,5 @@
-from typing import Union
 import os
+from typing import Union
 
 from piston.utils import helpers, services
 from piston.utils.constants import CONSOLE, PistonQuery
@@ -21,13 +21,11 @@ class FromFile:
             CONSOLE.print("Path is invalid; File not found", style="bold red")
             helpers.close()
 
-        with open(file, 'r' ,encoding="utf-8") as f:
+        with open(file, "r", encoding="utf-8") as f:
             code = f.read()
 
         if not any(file.endswith("." + ext) for ext in self.extensions):
-            CONSOLE.print(
-                "File Extension language is not supported!", style="bold red"
-            )            
+            CONSOLE.print("File Extension language is not supported!", style="bold red")
             helpers.close()
 
         # try:

--- a/piston/commands/from_file.py
+++ b/piston/commands/from_file.py
@@ -1,4 +1,5 @@
 from typing import Union
+import os
 
 from piston.utils import helpers, services
 from piston.utils.constants import CONSOLE, PistonQuery
@@ -16,19 +17,32 @@ class FromFile:
         args = helpers.get_args()
         stdin = helpers.get_stdin()
 
-        try:
-            with open(file, "r", encoding="utf-8") as f:
-                code = f.read()
-
-            if not any(file.endswith("." + ext) for ext in self.extensions):
-                CONSOLE.print(
-                    "File Extension language is not supported!", style="bold red"
-                )
-                helpers.close()
-
-        except FileNotFoundError:
+        if not os.path.isfile(file):
             CONSOLE.print("Path is invalid; File not found", style="bold red")
             helpers.close()
+
+        with open(file, 'r' ,encoding="utf-8") as f:
+            code = f.read()
+
+        if not any(file.endswith("." + ext) for ext in self.extensions):
+            CONSOLE.print(
+                "File Extension language is not supported!", style="bold red"
+            )            
+            helpers.close()
+
+        # try:
+        #     with open(file, "r", encoding="utf-8") as f:
+        #         code = f.read()
+
+        #     if not any(file.endswith("." + ext) for ext in self.extensions):
+        #         CONSOLE.print(
+        #             "File Extension language is not supported!", style="bold red"
+        #         )
+        #         helpers.close()
+
+        # except FileNotFoundError:
+        #     CONSOLE.print("Path is invalid; File not found", style="bold red")
+        #     helpers.close()
 
         language = self.extensions[file[file.rfind(".") + 1 :]]
 

--- a/piston/commands/from_file.py
+++ b/piston/commands/from_file.py
@@ -27,21 +27,7 @@ class FromFile:
         if not any(file.endswith("." + ext) for ext in self.extensions):
             CONSOLE.print("File Extension language is not supported!", style="bold red")
             helpers.close()
-
-        # try:
-        #     with open(file, "r", encoding="utf-8") as f:
-        #         code = f.read()
-
-        #     if not any(file.endswith("." + ext) for ext in self.extensions):
-        #         CONSOLE.print(
-        #             "File Extension language is not supported!", style="bold red"
-        #         )
-        #         helpers.close()
-
-        # except FileNotFoundError:
-        #     CONSOLE.print("Path is invalid; File not found", style="bold red")
-        #     helpers.close()
-
+            
         language = self.extensions[file[file.rfind(".") + 1 :]]
 
         payload = PistonQuery(

--- a/piston/commands/from_file.py
+++ b/piston/commands/from_file.py
@@ -18,7 +18,7 @@ class FromFile:
         stdin = helpers.get_stdin()
 
         if not os.path.isfile(file):
-            CONSOLE.print("Path is invalid; File not found", style="bold red")
+            CONSOLE.print("[bold red]Path is invalid; File not found[/bold red]")
             helpers.close()
 
         with open(file, "r", encoding="utf-8") as f:

--- a/piston/commands/from_file.py
+++ b/piston/commands/from_file.py
@@ -25,7 +25,7 @@ class FromFile:
             code = f.read()
 
         if not any(file.endswith("." + ext) for ext in self.extensions):
-            CONSOLE.print("File Extension language is not supported!", style="bold red")
+            CONSOLE.print("[bold red]File Extension language is not supported![/bold red]")
             helpers.close()
             
         language = self.extensions[file[file.rfind(".") + 1 :]]

--- a/piston/utils/helpers.py
+++ b/piston/utils/helpers.py
@@ -28,13 +28,16 @@ def close() -> None:
     except SystemExit:
         os._exit(1)
 
-def input_prompt(text:str) -> str:
+
+def input_prompt(text: str) -> str:
+    """Prompt the user."""
     try:
         user_input = CONSOLE.input(text)
         return user_input
     except KeyboardInterrupt:
         CONSOLE.print("\n[red]Keyboard interrupt[/red]")
         close()
+
 
 def print_msg_box(msg: str, style: str = "HORIZONTALS") -> Table:
     """Print message-box with optional style, passed from user's configuration."""

--- a/piston/utils/helpers.py
+++ b/piston/utils/helpers.py
@@ -35,7 +35,6 @@ def input_prompt(text: str) -> str:
         user_input = CONSOLE.input(text)
         return user_input
     except KeyboardInterrupt:
-        CONSOLE.print("\n[red]Keyboard interrupt[/red]")
         close()
 
 

--- a/piston/utils/helpers.py
+++ b/piston/utils/helpers.py
@@ -28,6 +28,13 @@ def close() -> None:
     except SystemExit:
         os._exit(1)
 
+def input_prompt(text:str) -> str:
+    try:
+        user_input = CONSOLE.input(text)
+        return user_input
+    except KeyboardInterrupt:
+        CONSOLE.print("\n[red]Keyboard interrupt[/red]")
+        close()
 
 def print_msg_box(msg: str, style: str = "HORIZONTALS") -> Table:
     """Print message-box with optional style, passed from user's configuration."""
@@ -53,7 +60,7 @@ def get_lang() -> str:
 
     If language is not supported then exit the CLI.
     """
-    language = CONSOLE.input("[green]Enter language:[/green] ").lower()
+    language = input_prompt("[green]Enter language:[/green] ").lower()
 
     if language not in languages_:
         CONSOLE.print("[bold red]Language is not supported![/bold red]")
@@ -63,13 +70,13 @@ def get_lang() -> str:
 
 def get_args() -> list[str]:
     """Prompt the user for the command line arguments."""
-    args = CONSOLE.input("[green]Enter your args separated:[/green] ")
+    args = input_prompt("[green]Enter your args separated:[/green] ")
     return parse_string(args)
 
 
 def get_stdin() -> str:
     """Prompt the user for the standard input."""
-    stdin = CONSOLE.input("[green]Enter your stdin arguments:[/green] ")
+    stdin = input_prompt("[green]Enter your stdin arguments:[/green] ")
     return "\n".join(parse_string(stdin))
 
 

--- a/test.py
+++ b/test.py
@@ -1,3 +1,0 @@
-from piston import main
-
-main()

--- a/test.py
+++ b/test.py
@@ -1,0 +1,3 @@
+from piston import main
+
+main()


### PR DESCRIPTION
- Prevent inputs from capturing keyboard interrupts.
- Replaced `try..except` block with `os.path.isfile(filename)` for validating files


 - [x] Join the Piston CLI Discord Community?
 - [x] If dependencies have been added or updated, run pipenv lock?
 - [x] Lint your code (pipenv run lint)?
 - [ ] Set the PR to allow edits from contributors?